### PR TITLE
Fix empty hashtables, -as, -not, -bor, -band, and IEnumerable<> index expressions

### DIFF
--- a/src/PSLambda/CompileVisitor.cs
+++ b/src/PSLambda/CompileVisitor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -549,7 +549,7 @@ namespace PSLambda
                 source.Type.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
             {
                 if (genericEnumerable == null)
-            {
+                {
                     genericEnumerable = source.Type;
                 }
 

--- a/src/PSLambda/CompileVisitor.cs
+++ b/src/PSLambda/CompileVisitor.cs
@@ -916,6 +916,8 @@ namespace PSLambda
                     return Assign(child, Increment(child));
                 case TokenKind.PostfixMinusMinus:
                     return Assign(child, Decrement(child));
+                case TokenKind.Not:
+                    return Not(PSIsTrue(child));
                 default:
                     ReportNotSupported(
                         unaryExpressionAst.Extent,

--- a/src/PSLambda/CompileVisitor.cs
+++ b/src/PSLambda/CompileVisitor.cs
@@ -544,8 +544,15 @@ namespace PSLambda
                     new[] { indexExpressionAst.Index.Compile(this) });
             }
 
-            if (TryFindGenericInterface(source.Type, typeof(IEnumerable<>), out Type genericEnumerable))
+            if (TryFindGenericInterface(source.Type, typeof(IEnumerable<>), out Type genericEnumerable) ||
+                (source.Type.IsGenericType &&
+                source.Type.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
             {
+                if (genericEnumerable == null)
+            {
+                    genericEnumerable = source.Type;
+                }
+
                 Expression index;
                 try
                 {

--- a/src/PSLambda/CompileVisitor.cs
+++ b/src/PSLambda/CompileVisitor.cs
@@ -244,9 +244,9 @@ namespace PSLambda
                 case TokenKind.Or:
                     return OrElse(PSIsTrue(lhs), PSIsTrue(rhs));
                 case TokenKind.Band:
-                    return And(lhs, rhs);
+                    return PSBitwiseOperation(ExpressionType.And, lhs, rhs);
                 case TokenKind.Bor:
-                    return Or(lhs, rhs);
+                    return PSBitwiseOperation(ExpressionType.Or, lhs, rhs);
                 case TokenKind.Is:
                     if (rhsTypeConstant == null)
                     {

--- a/src/PSLambda/CompileVisitor.cs
+++ b/src/PSLambda/CompileVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -488,6 +488,14 @@ namespace PSLambda
 
         public object VisitHashtable(HashtableAst hashtableAst)
         {
+            if (hashtableAst.KeyValuePairs.Count == 0)
+            {
+                return New(
+                    ReflectionCache.Hashtable_Ctor,
+                    Constant(0),
+                    Property(null, ReflectionCache.StringComparer_CurrentCultureIgnoreCase));
+            }
+
             var elements = new ElementInit[hashtableAst.KeyValuePairs.Count];
             for (var i = 0; i < elements.Length; i++)
             {

--- a/src/PSLambda/CompileVisitor.cs
+++ b/src/PSLambda/CompileVisitor.cs
@@ -802,6 +802,15 @@ namespace PSLambda
             {
                 using (_loops.NewScope())
                 {
+                    if (switchStatementAst.Clauses.Count == 0)
+                    {
+                        return new[]
+                        {
+                            switchStatementAst.Default.Compile(this),
+                            Label(_loops.Break)
+                        };
+                    }
+
                     var clauses = new SwitchCase[switchStatementAst.Clauses.Count];
                     for (var i = 0; i < clauses.Length; i++)
                     {

--- a/src/PSLambda/ExpressionUtils.cs
+++ b/src/PSLambda/ExpressionUtils.cs
@@ -352,6 +352,39 @@ namespace PSLambda
                 PSConvertTo<int>(rhs));
         }
 
+        /// <summary>
+        /// Creates an <see cref="Expression" /> representing the evaluation of a bitwise comparision
+        /// operator from the PowerShell engine.
+        /// </summary>
+        /// <param name="expressionType">The expression operator.</param>
+        /// <param name="lhs">The <see cref="Expression" /> on the left hand side.</param>
+        /// <param name="rhs">The <see cref="Expression" /> on the right hand side.</param>
+        /// <returns>An <see cref="Expression" /> representing the operation.</returns>
+        public static Expression PSBitwiseOperation(
+            ExpressionType expressionType,
+            Expression lhs,
+            Expression rhs)
+        {
+            var resultType = lhs.Type;
+            if (typeof(Enum).IsAssignableFrom(lhs.Type))
+            {
+                lhs = Convert(lhs, Enum.GetUnderlyingType(lhs.Type));
+            }
+
+            if (typeof(Enum).IsAssignableFrom(rhs.Type))
+            {
+                rhs = Convert(rhs, Enum.GetUnderlyingType(rhs.Type));
+            }
+
+            var resultExpression = MakeBinary(expressionType, lhs, rhs);
+            if (resultType == resultExpression.Type)
+            {
+                return resultExpression;
+            }
+
+            return PSConvertTo(resultExpression, resultType);
+        }
+
         private static bool PSEqualsIgnoreCase(object first, object second)
         {
             return LanguagePrimitives.Compare(first, second, ignoreCase: true) == 0;

--- a/src/PSLambda/ReflectionCache.cs
+++ b/src/PSLambda/ReflectionCache.cs
@@ -61,7 +61,7 @@ namespace PSLambda
                     var parameters = method.GetParameters();
                     return parameters.Length == 2
                         && parameters[0].ParameterType == typeof(object)
-                        && parameters[1].ParameterType.IsGenericParameter;
+                        && parameters[1].ParameterType.IsByRef;
                 },
                 null)
                 .FirstOrDefault();

--- a/test/Loops.Tests.ps1
+++ b/test/Loops.Tests.ps1
@@ -70,4 +70,85 @@ Describe 'basic loop functionality' {
 
         $delegate.Invoke() | Should -Be 11
     }
+
+    It 'break continues after loop' {
+        $delegate = New-PSDelegate {
+            $i = 0
+            $continuedAfterBreak = $false
+            while ($i -lt 10) {
+                $i++
+                if ($i -eq 5) {
+                    break
+                    $continuedAfterBreak = $true
+                }
+            }
+
+            if ($continuedAfterBreak) {
+                throw 'code after "break" was executed'
+            }
+
+            return $i
+        }
+
+        $delegate.Invoke() | Should -Be 5
+    }
+
+    It 'continue steps to next interation' {
+        $delegate = New-PSDelegate {
+            $i = 0
+            $continuedAfterContinue = $false
+            while ($i -lt 10) {
+                $i++
+                continue
+                $continuedAfterContinue = $true
+            }
+
+            if ($continuedAfterContinue) {
+                throw 'code after "continue" was executed'
+            }
+
+            return $i
+        }
+
+        $delegate.Invoke() | Should -Be 10
+    }
+
+    Context 'switch statement' {
+        It 'chooses correct value' {
+            $hitValues = [System.Collections.Generic.List[string]]::new()
+            $delegate = New-PSDelegate {
+                foreach ($value in 'value1', 'value2', 'value3', 'invalid') {
+                    switch ($value) {
+                        value1 { $hitValues.Add('option1') }
+                        value2 { $hitValues.Add('option2') }
+                        value3 { $hitValues.Add('option3') }
+                        default { throw }
+                    }
+                }
+            }
+
+            { $delegate.Invoke() } | Should -Throw
+            $hitValues | Should -Be 'option1', 'option2', 'option3'
+        }
+
+        It 'can have a single value' {
+            $delegate = New-PSDelegate {
+                switch ('value') {
+                    value { return 'value' }
+                }
+            }
+
+            $delegate.Invoke() | Should -Be 'value'
+        }
+
+        It 'can have a default without cases' {
+            $delegate = New-PSDelegate {
+                switch ('value') {
+                    default { return 'value' }
+                }
+            }
+
+            $delegate.Invoke() | Should -Be 'value'
+        }
+    }
 }

--- a/test/MiscLanguageFeatures.Tests.ps1
+++ b/test/MiscLanguageFeatures.Tests.ps1
@@ -4,24 +4,33 @@ $manifestPath = "$PSScriptRoot\..\Release\$moduleName\*\$moduleName.psd1"
 Import-Module $manifestPath -Force
 
 Describe 'Misc Language Features' {
-    It 'Hashtable expression' {
+    It 'expandable string expression' {
         $delegate = New-PSDelegate {
+            $one = "1"
+            $two = 2
+            $three = 'something'
+            return "This is a string with $one random $two numbers and $three"
+        }
+
+        $delegate.Invoke() | Should -Be 'This is a string with 1 random 2 numbers and something'
+    }
+
     Context 'hashtable tests' {
         It 'handles varied types of values' {
             $delegate = New-PSDelegate {
-            return @{
-                'string' = 'value'
-                string2 = 10
-                Object = [object]::new()
+                return @{
+                    'string' = 'value'
+                    string2 = 10
+                    Object = [object]::new()
+                }
             }
-        }
 
-        $hashtable = $delegate.Invoke()
-        $hashtable['string'] | Should -Be 'value'
-        $hashtable['string2'] | Should -Be 10
-        $hashtable['Object'] | Should -BeOfType object
-        $hashtable['object'] | Should -BeOfType object
-    }
+            $hashtable = $delegate.Invoke()
+            $hashtable['string'] | Should -Be 'value'
+            $hashtable['string2'] | Should -Be 10
+            $hashtable['Object'] | Should -BeOfType object
+            $hashtable['object'] | Should -BeOfType object
+        }
 
         It 'can initialize an empty hashtable' {
             (New-PSDelegate { @{} }).Invoke().GetType() | Should -Be ([hashtable])
@@ -68,6 +77,26 @@ Describe 'Misc Language Features' {
             $result[0].GetType() | Should -Be ([int])
             $result | Should -Be 1
         }
+
+        It 'creates an empty array' {
+            $result = (New-PSDelegate { @() }).Invoke()
+            $result.GetType() | Should -Be ([object[]])
+            $result.Length | Should -Be 0
+        }
+
+        It 'can take multiple statements in an array' {
+            $delegate = New-PSDelegate {
+                return @(
+                    0..10
+                    10..20)
+            }
+
+            $result = $delegate.Invoke()
+            $result.GetType() | Should -Be ([int[][]])
+            $result.Count | Should -Be 2
+            $result[0] | Should -Be (0..10)
+            $result[1] | Should -Be (10..20)
+        }
     }
 
     Context 'assignments' {
@@ -93,6 +122,112 @@ Describe 'Misc Language Features' {
         It 'can not access a variable declared in a child scope' {
             { (New-PSDelegate { if ($true) { $a = 10 }; return $a }).Invoke() } |
                 Should -Throw 'The variable "a" was referenced before it was defined or was defined in a sibling scope'
+        }
+
+        It 'can assign to an index operation' {
+            $delegate = New-PSDelegate {
+                $hash = @{ Key = 'Value' }
+                $hash['Key'] = 'NewValue'
+                return $hash
+            }
+
+            $delegate.Invoke().Key | Should -Be 'NewValue'
+        }
+
+        It 'can assign to a property' {
+            $delegate = New-PSDelegate {
+                $verboseRecord = [System.Management.Automation.VerboseRecord]::new('original message')
+                $verboseRecord.Message = 'new message'
+                return $verboseRecord
+            }
+
+            $delegate.Invoke().Message | Should -Be 'new message'
+        }
+
+        It 'minus equals' {
+            $delegate = New-PSDelegate {
+                $a = 10
+                $a -= 5
+                return $a
+            }
+
+            $delegate.Invoke() | Should -Be 5
+        }
+
+        It 'multiply equals' {
+            $delegate = New-PSDelegate {
+                $a = 10
+                $a *= 5
+                return $a
+            }
+
+            $delegate.Invoke() | Should -Be 50
+        }
+
+        It 'divide equals' {
+            $delegate = New-PSDelegate {
+                $a = 10
+                $a /= 5
+                return $a
+            }
+
+            $delegate.Invoke() | Should -Be 2
+        }
+
+        It 'remainder equals' {
+            $delegate = New-PSDelegate {
+                $a = 10
+                $a %= 6
+                return $a
+            }
+
+            $delegate.Invoke() | Should -Be 4
+        }
+    }
+
+    Context 'indexer inference' {
+        It 'indexed IList<> are typed property' {
+            $delegate = New-PSDelegate {
+                $list = [System.Collections.Generic.List[string]]::new()
+                $list.Add('test')
+                return $list[0].EndsWith('t')
+            }
+
+            $delegate.Invoke() | Should -Be $true
+        }
+
+        It 'indexed IDictionary<,> are typed property' {
+            $delegate = New-PSDelegate {
+                $list = [System.Collections.Generic.Dictionary[string, type]]::new()
+                $list.Add('test', [type])
+                return $list['test'].Namespace
+            }
+
+            $delegate.Invoke() | Should -Be 'System'
+        }
+
+        It 'indexed IEnumerable<> are typed properly' {
+            $delegate = New-PSDelegate {
+                $strings = generic(
+                    [System.Linq.Enumerable]::Select(
+                        ('test', 'test2', 'test3'),
+                        [func[string, string]]{ ($string) => { $string }}),
+                    [string], [string])
+
+                return $strings[1].EndsWith('2')
+            }
+
+            $delegate.Invoke() | Should -Be $true
+        }
+
+        It 'can index IList' {
+            $delegate = New-PSDelegate {
+                $list = [System.Collections.ArrayList]::new()
+                $list.AddRange([object[]]('one', 'two', 'three'))
+                return [string]$list[1] -eq 'two'
+            }
+
+            $delegate.Invoke() | Should -Be $true
         }
     }
 }

--- a/test/MiscLanguageFeatures.Tests.ps1
+++ b/test/MiscLanguageFeatures.Tests.ps1
@@ -6,6 +6,9 @@ Import-Module $manifestPath -Force
 Describe 'Misc Language Features' {
     It 'Hashtable expression' {
         $delegate = New-PSDelegate {
+    Context 'hashtable tests' {
+        It 'handles varied types of values' {
+            $delegate = New-PSDelegate {
             return @{
                 'string' = 'value'
                 string2 = 10
@@ -18,6 +21,11 @@ Describe 'Misc Language Features' {
         $hashtable['string2'] | Should -Be 10
         $hashtable['Object'] | Should -BeOfType object
         $hashtable['object'] | Should -BeOfType object
+    }
+
+        It 'can initialize an empty hashtable' {
+            (New-PSDelegate { @{} }).Invoke().GetType() | Should -Be ([hashtable])
+        }
     }
 
     Context 'array literal' {

--- a/test/Operator.Tests.ps1
+++ b/test/Operator.Tests.ps1
@@ -187,4 +187,15 @@ Describe 'operator tests' {
         (New-PSDelegate { 'this' -ceq 'that' }).Invoke() | Should -Be $false
         (New-PSDelegate { 'this' -ceq 'This' }).Invoke() | Should -Be $false
     }
+    It 'Bor' {
+        (New-PSDelegate { [Reflection.BindingFlags]::Instance -bor [Reflection.BindingFlags]::Public }).Invoke() |
+            Should -Be ([Reflection.BindingFlags]'Instance, Public')
+    }
+
+    It 'Band' {
+        $flags = [Reflection.BindingFlags]'Instance, Public'
+        (New-PSDelegate { $flags -band [Reflection.BindingFlags]::Public }).Invoke() |
+            Should -Be ([Reflection.BindingFlags]'Public')
+    }
+
 }

--- a/test/Operator.Tests.ps1
+++ b/test/Operator.Tests.ps1
@@ -98,6 +98,20 @@ Describe 'operator tests' {
         (New-PSDelegate { 'That' -clike 'that' }).Invoke() | Should -Be $false
     }
 
+    It 'Inotlike' {
+        (New-PSDelegate { 'this' -notlike 't*s' }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'that' -notlike 't*s' }).Invoke() | Should -Be $true
+        (New-PSDelegate { 01243 -notlike '*4*' }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'That' -notlike 'that' }).Invoke() | Should -Be $false
+    }
+
+    It 'Cnotlike' {
+        (New-PSDelegate { 'this' -cnotlike 't*s' }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'that' -cnotlike 't*s' }).Invoke() | Should -Be $true
+        (New-PSDelegate { 01243 -cnotlike '*4*' }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'That' -cnotlike 'that' }).Invoke() | Should -Be $true
+    }
+
     It 'Imatch' {
         (New-PSDelegate { 'this' -match 'This' }).Invoke() | Should -Be $true
         (New-PSDelegate { 'this' -match 't[hi]{2}s' }).Invoke() | Should -Be $true
@@ -108,6 +122,18 @@ Describe 'operator tests' {
         (New-PSDelegate { 'this' -cmatch 'This' }).Invoke() | Should -Be $false
         (New-PSDelegate { 'this' -cmatch 't[hi]{2}s' }).Invoke() | Should -Be $true
         (New-PSDelegate { 'this' -cmatch '\w+' }).Invoke() | Should -Be $true
+    }
+
+    It 'Inotmatch' {
+        (New-PSDelegate { 'this' -notmatch 'This' }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'this' -notmatch 't[hi]{2}s' }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'this' -notmatch '\w+' }).Invoke() | Should -Be $false
+    }
+
+    It 'Cnotmatch' {
+        (New-PSDelegate { 'this' -cnotmatch 'This' }).Invoke() | Should -Be $true
+        (New-PSDelegate { 'this' -cnotmatch 't[hi]{2}s' }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'this' -cnotmatch '\w+' }).Invoke() | Should -Be $false
     }
 
     It 'Igt' {
@@ -187,6 +213,40 @@ Describe 'operator tests' {
         (New-PSDelegate { 'this' -ceq 'that' }).Invoke() | Should -Be $false
         (New-PSDelegate { 'this' -ceq 'This' }).Invoke() | Should -Be $false
     }
+
+    It 'Join' {
+        (New-PSDelegate { 0, 2, 4 -join '' }).Invoke() | Should -Be '024'
+        (New-PSDelegate { ([type], [string], [int]) -join '-'}).Invoke() | Should -Be 'type-string-int'
+    }
+
+    It 'Ireplace' {
+        (New-PSDelegate { 'Test string' -replace 't', 'w' }).Invoke() | Should -Be 'wesw swring'
+        (New-PSDelegate { 'Test string' -replace '^[A-Z]+', '-$0-' }).Invoke() | Should -Be '-Test- string'
+    }
+
+    It 'Creplace' {
+        (New-PSDelegate { 'Test string' -creplace 't', 'w' }).Invoke() | Should -Be 'Tesw swring'
+        (New-PSDelegate { 'Test string' -creplace '^[A-Z]+', '-$0-' }).Invoke() | Should -Be '-T-est string'
+    }
+
+    It 'And' {
+        (New-PSDelegate { 'string' -and $true }).Invoke() | Should -Be $true
+        (New-PSDelegate { 'string' -and $false }).Invoke() | Should -Be $false
+        (New-PSDelegate { $false -and $false }).Invoke() | Should -Be $false
+    }
+
+    It 'Or' {
+        (New-PSDelegate { 'string' -or $true }).Invoke() | Should -Be $true
+        (New-PSDelegate { 'string' -or $false }).Invoke() | Should -Be $true
+        (New-PSDelegate { $false -or $false }).Invoke() | Should -Be $false
+        (New-PSDelegate { $false -or $true }).Invoke() | Should -Be $true
+    }
+
+    It 'Not' {
+        (New-PSDelegate { -not $false }).Invoke() | Should -Be $true
+        (New-PSDelegate { -not $true }).Invoke() | Should -Be $false
+    }
+
     It 'Bor' {
         (New-PSDelegate { [Reflection.BindingFlags]::Instance -bor [Reflection.BindingFlags]::Public }).Invoke() |
             Should -Be ([Reflection.BindingFlags]'Instance, Public')
@@ -198,4 +258,41 @@ Describe 'operator tests' {
             Should -Be ([Reflection.BindingFlags]'Public')
     }
 
+    It 'As' {
+        (New-PSDelegate { 'string' -as [type] }).Invoke() | Should -Be ([string])
+        (New-PSDelegate { 'does_not_exist' -as [type] }).Invoke() | Should -Be $null
+        { New-PSDelegate { 'this' -as 'that' }} | Should -Throw '-as or -is expression with non-literal type.'
+    }
+
+    It 'Is' {
+        (New-PSDelegate { 'string' -is [string] }).Invoke() | Should -Be $true
+        (New-PSDelegate { 10 -is [int] }).Invoke() | Should -Be $true
+        (New-PSDelegate { 'string' -is [int] }).Invoke() | Should -Be $false
+    }
+
+    It 'Isnot' {
+        (New-PSDelegate { 'string' -isnot [string] }).Invoke() | Should -Be $false
+        (New-PSDelegate { 10 -isnot [int] }).Invoke() | Should -Be $false
+        (New-PSDelegate { 'string' -isnot [int] }).Invoke() | Should -Be $true
+    }
+
+    It 'Add' {
+        (New-PSDelegate { 2 + 1 }).Invoke() | Should -Be 3
+    }
+
+    It 'Subtract' {
+        (New-PSDelegate { 2 - 1 }).Invoke() | Should -Be 1
+    }
+
+    It 'Divide' {
+        (New-PSDelegate { 4 / 2 }).Invoke() | Should -Be 2
+    }
+
+    It 'Multiply' {
+        (New-PSDelegate { 4 * 2 }).Invoke() | Should -Be 8
+    }
+
+    It 'Rem' {
+        (New-PSDelegate { 4 % 3 }).Invoke() | Should -Be 1
+    }
 }


### PR DESCRIPTION
Fix an an exceptions on

- Empty `Hashtable` initialization expressions
- Switch statements with just a `default` block
- Index operations on expressions typed explicitly as `IEnumerable<>`
- The `-as` and `-not` operators
- The `-bor`  and `-band` operators when used against an `Enum`

Also added some more tests.

Resolves #7