### PR TITLE
Add custom method resolution

### DIFF
--- a/src/PSLambda/Commands/GenericCommand.cs
+++ b/src/PSLambda/Commands/GenericCommand.cs
@@ -76,7 +76,7 @@ namespace PSLambda.Commands
 
         private Expression ReportInvalidSyntax(IScriptExtent extent, CompileVisitor visitor)
         {
-            visitor.ReportParseError(
+            visitor.Errors.ReportParseError(
                 extent,
                 nameof(ErrorStrings.InvalidGenericSyntax),
                 ErrorStrings.InvalidGenericSyntax);

--- a/src/PSLambda/Commands/WithCommand.cs
+++ b/src/PSLambda/Commands/WithCommand.cs
@@ -25,7 +25,7 @@ namespace PSLambda.Commands
         {
             if (commandAst.CommandElements.Count != 3)
             {
-                visitor.ReportParseError(
+                visitor.Errors.ReportParseError(
                     commandAst.Extent,
                     nameof(ErrorStrings.MissingWithElements),
                     ErrorStrings.MissingWithElements);
@@ -35,7 +35,7 @@ namespace PSLambda.Commands
             var bodyAst = commandAst.CommandElements[2] as ScriptBlockExpressionAst;
             if (bodyAst == null)
             {
-                visitor.ReportParseError(
+                visitor.Errors.ReportParseError(
                     commandAst.Extent,
                     nameof(ErrorStrings.MissingWithBody),
                     ErrorStrings.MissingWithBody);

--- a/src/PSLambda/DelegateSyntaxVisitor.cs
+++ b/src/PSLambda/DelegateSyntaxVisitor.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+
+namespace PSLambda
+{
+    /// <summary>
+    /// Provides the ability to reshape a <see cref="ScriptBlockAst" /> when it fits
+    /// the custom syntax for anonymous method expressions.
+    /// </summary>
+    internal class DelegateSyntaxVisitor : ICustomAstVisitor
+    {
+        private static RedirectionAst[] s_emptyRedirections = new RedirectionAst[0];
+
+        private static TrapStatementAst[] s_emptyTraps = new TrapStatementAst[0];
+
+        private static AttributeAst[] s_emptyAttributes = new AttributeAst[0];
+
+        private readonly IParseErrorWriter _errorWriter;
+
+        private readonly List<Tuple<ITypeName, VariableExpressionAst>> _variables = new List<Tuple<ITypeName, VariableExpressionAst>>();
+
+        private IScriptExtent _paramBlockExtent;
+
+        private bool _failed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegateSyntaxVisitor" /> class.
+        /// </summary>
+        /// <param name="errorWriter">The <see cref="IParseErrorWriter" /> to report errors to.</param>
+        internal DelegateSyntaxVisitor(IParseErrorWriter errorWriter)
+        {
+            _errorWriter = errorWriter;
+        }
+
+        #pragma warning disable SA1600
+        public object VisitScriptBlockExpression(ScriptBlockExpressionAst scriptBlockExpressionAst)
+        {
+            return scriptBlockExpressionAst.ScriptBlock.Visit(this);
+        }
+
+        public object VisitScriptBlock(ScriptBlockAst scriptBlockAst)
+        {
+            if (scriptBlockAst.ParamBlock != null)
+            {
+                return scriptBlockAst;
+            }
+
+            if (scriptBlockAst.BeginBlock != null)
+            {
+                _errorWriter.ReportNotSupported(
+                    scriptBlockAst.BeginBlock.Extent,
+                    nameof(CompilerStrings.BeginBlock),
+                    CompilerStrings.BeginBlock);
+                return null;
+            }
+
+            if (scriptBlockAst.ProcessBlock != null)
+            {
+                _errorWriter.ReportNotSupported(
+                    scriptBlockAst.ProcessBlock.Extent,
+                    nameof(CompilerStrings.ProcessBlock),
+                    CompilerStrings.ProcessBlock);
+                return null;
+            }
+
+            if (scriptBlockAst.EndBlock == null)
+            {
+                _errorWriter.ReportMissing(
+                    scriptBlockAst.Extent,
+                    nameof(CompilerStrings.EndBlock),
+                    CompilerStrings.EndBlock);
+                return null;
+            }
+
+            var body = scriptBlockAst.EndBlock.Visit(this);
+            if (_failed)
+            {
+                return scriptBlockAst;
+            }
+
+            _errorWriter.ThrowIfAnyErrors();
+            var parameters = new ParameterAst[_variables.Count];
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                parameters[i] = new ParameterAst(
+                    _variables[i].Item2.Extent,
+                    (VariableExpressionAst)_variables[i].Item2.Copy(),
+                    new[] { new TypeConstraintAst(_variables[i].Item1.Extent, _variables[i].Item1) },
+                    null);
+            }
+
+            var paramBlock =
+                new ParamBlockAst(
+                    _paramBlockExtent,
+                    s_emptyAttributes,
+                    parameters);
+
+            return new ScriptBlockAst(
+                scriptBlockAst.Extent,
+                paramBlock,
+                null,
+                null,
+                (NamedBlockAst)((Ast)body).Copy(),
+                null);
+        }
+
+        public object VisitNamedBlock(NamedBlockAst namedBlockAst)
+        {
+            if (namedBlockAst.Statements == null ||
+                namedBlockAst.Statements.Count == 0)
+            {
+                _errorWriter.ReportMissing(
+                    namedBlockAst.Extent,
+                    nameof(CompilerStrings.EndBlock),
+                    CompilerStrings.EndBlock);
+                return null;
+            }
+
+            if (namedBlockAst.Statements.Count > 1)
+            {
+                _failed = true;
+                return null;
+            }
+
+            var body = namedBlockAst.Statements[0].Visit(this);
+            if (body == null)
+            {
+                _failed = true;
+                return null;
+            }
+
+            return body;
+        }
+
+        public object VisitPipeline(PipelineAst pipelineAst)
+        {
+            return pipelineAst.PipelineElements[0].Visit(this);
+        }
+
+        public object VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst)
+        {
+            _paramBlockExtent = assignmentStatementAst.Left.Extent;
+            DelegateParameterVisitor.AddVariables(
+                assignmentStatementAst.Left,
+                _variables);
+
+            var pipeline = assignmentStatementAst.Right as PipelineAst;
+            if (pipeline == null)
+            {
+                return null;
+            }
+
+            var commandAst = pipeline.PipelineElements[0] as CommandAst;
+            if (commandAst == null ||
+                commandAst.GetCommandName() != Strings.DelegateSyntaxCommandName ||
+                commandAst.CommandElements.Count != 2)
+            {
+                return null;
+            }
+
+            if (commandAst.CommandElements[1] is ScriptBlockExpressionAst sbAst)
+            {
+                return sbAst.ScriptBlock.EndBlock;
+            }
+
+            var expression = commandAst.CommandElements[1] as ExpressionAst;
+
+            var statements =
+                new StatementAst[]
+                {
+                    new CommandExpressionAst(
+                        expression.Extent,
+                        (ExpressionAst)expression.Copy(),
+                        s_emptyRedirections)
+                };
+
+            var statementBlockAst = new StatementBlockAst(
+                commandAst.CommandElements[1].Extent,
+                statements,
+                s_emptyTraps);
+
+            return new NamedBlockAst(
+                commandAst.CommandElements[1].Extent,
+                TokenKind.End,
+                statementBlockAst,
+                unnamed: true);
+        }
+        #pragma warning restore SA1600
+
+        private class DelegateParameterVisitor : AstVisitor
+        {
+            private static ITypeName s_objectTypeName = new TypeName(
+                Empty.Extent,
+                typeof(object).FullName);
+
+            private List<Tuple<ITypeName, VariableExpressionAst>> _variables = new List<Tuple<ITypeName, VariableExpressionAst>>();
+
+            private DelegateParameterVisitor()
+            {
+            }
+
+            public static void AddVariables(
+                ExpressionAst expression,
+                List<Tuple<ITypeName, VariableExpressionAst>> variables)
+            {
+                var visitor = new DelegateParameterVisitor();
+                visitor._variables = variables;
+                expression.Visit(visitor);
+            }
+
+            public override AstVisitAction VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
+            {
+                if (convertExpressionAst.Child is VariableExpressionAst variable)
+                {
+                    _variables.Add(
+                        Tuple.Create(
+                            convertExpressionAst.Attribute.TypeName,
+                            variable));
+
+                    return AstVisitAction.SkipChildren;
+                }
+
+                return AstVisitAction.StopVisit;
+            }
+
+            public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
+            {
+                _variables.Add(
+                    Tuple.Create(
+                        s_objectTypeName,
+                        variableExpressionAst));
+
+                return AstVisitAction.SkipChildren;
+            }
+        }
+
+        #pragma warning disable SA1600, SA1201, SA1516
+        public object VisitArrayExpression(ArrayExpressionAst arrayExpressionAst) => null;
+        public object VisitArrayLiteral(ArrayLiteralAst arrayLiteralAst) => null;
+        public object VisitAttribute(AttributeAst attributeAst) => null;
+        public object VisitAttributedExpression(AttributedExpressionAst attributedExpressionAst) => null;
+        public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst) => null;
+        public object VisitBlockStatement(BlockStatementAst blockStatementAst) => null;
+        public object VisitBreakStatement(BreakStatementAst breakStatementAst) => null;
+        public object VisitCatchClause(CatchClauseAst catchClauseAst) => null;
+        public object VisitCommand(CommandAst commandAst) => null;
+        public object VisitCommandExpression(CommandExpressionAst commandExpressionAst) => null;
+        public object VisitCommandParameter(CommandParameterAst commandParameterAst) => null;
+        public object VisitConstantExpression(ConstantExpressionAst constantExpressionAst) => null;
+        public object VisitContinueStatement(ContinueStatementAst continueStatementAst) => null;
+        public object VisitConvertExpression(ConvertExpressionAst convertExpressionAst) => null;
+        public object VisitDataStatement(DataStatementAst dataStatementAst) => null;
+        public object VisitDoUntilStatement(DoUntilStatementAst doUntilStatementAst) => null;
+        public object VisitDoWhileStatement(DoWhileStatementAst doWhileStatementAst) => null;
+        public object VisitErrorExpression(ErrorExpressionAst errorExpressionAst) => null;
+        public object VisitErrorStatement(ErrorStatementAst errorStatementAst) => null;
+        public object VisitExitStatement(ExitStatementAst exitStatementAst) => null;
+        public object VisitExpandableStringExpression(ExpandableStringExpressionAst expandableStringExpressionAst) => null;
+        public object VisitFileRedirection(FileRedirectionAst fileRedirectionAst) => null;
+        public object VisitForEachStatement(ForEachStatementAst forEachStatementAst) => null;
+        public object VisitForStatement(ForStatementAst forStatementAst) => null;
+        public object VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst) => null;
+        public object VisitHashtable(HashtableAst hashtableAst) => null;
+        public object VisitIfStatement(IfStatementAst ifStmtAst) => null;
+        public object VisitIndexExpression(IndexExpressionAst indexExpressionAst) => null;
+        public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) => null;
+        public object VisitMemberExpression(MemberExpressionAst memberExpressionAst) => null;
+        public object VisitMergingRedirection(MergingRedirectionAst mergingRedirectionAst) => null;
+        public object VisitNamedAttributeArgument(NamedAttributeArgumentAst namedAttributeArgumentAst) => null;
+        public object VisitParamBlock(ParamBlockAst paramBlockAst) => null;
+        public object VisitParameter(ParameterAst parameterAst) => null;
+        public object VisitParenExpression(ParenExpressionAst parenExpressionAst) => null;
+        public object VisitReturnStatement(ReturnStatementAst returnStatementAst) => null;
+        public object VisitStatementBlock(StatementBlockAst statementBlockAst) => null;
+        public object VisitStringConstantExpression(StringConstantExpressionAst stringConstantExpressionAst) => null;
+        public object VisitSubExpression(SubExpressionAst subExpressionAst) => null;
+        public object VisitSwitchStatement(SwitchStatementAst switchStatementAst) => null;
+        public object VisitThrowStatement(ThrowStatementAst throwStatementAst) => null;
+        public object VisitTrap(TrapStatementAst trapStatementAst) => null;
+        public object VisitTryStatement(TryStatementAst tryStatementAst) => null;
+        public object VisitTypeConstraint(TypeConstraintAst typeConstraintAst) => null;
+        public object VisitTypeExpression(TypeExpressionAst typeExpressionAst) => null;
+        public object VisitUnaryExpression(UnaryExpressionAst unaryExpressionAst) => null;
+        public object VisitUsingExpression(UsingExpressionAst usingExpressionAst) => null;
+        public object VisitVariableExpression(VariableExpressionAst variableExpressionAst) => null;
+        public object VisitWhileStatement(WhileStatementAst whileStatementAst) => null;
+        #pragma warning restore SA1600, SA1201, SA1516
+    }
+}

--- a/src/PSLambda/Empty.cs
+++ b/src/PSLambda/Empty.cs
@@ -1,0 +1,58 @@
+using System.Management.Automation.Language;
+
+namespace PSLambda
+{
+    /// <summary>
+    /// Provides utility methods for empty elements.
+    /// </summary>
+    internal static class Empty
+    {
+        /// <summary>
+        /// Gets an empty <see cref="IScriptExtent" />.
+        /// </summary>
+        internal static IScriptExtent Extent => new EmptyScriptExtent();
+
+        /// <summary>
+        /// Gets an empty <see cref="IScriptPosition" />.
+        /// </summary>
+        internal static IScriptPosition Position => new EmptyScriptPosition();
+
+        private class EmptyScriptExtent : IScriptExtent
+        {
+            public int EndColumnNumber => 0;
+
+            public int EndLineNumber => 0;
+
+            public int EndOffset => 0;
+
+            public IScriptPosition EndScriptPosition => Position;
+
+            public string File => string.Empty;
+
+            public int StartColumnNumber => 0;
+
+            public int StartLineNumber => 0;
+
+            public int StartOffset => 0;
+
+            public IScriptPosition StartScriptPosition => Position;
+
+            public string Text => string.Empty;
+        }
+
+        private class EmptyScriptPosition : IScriptPosition
+        {
+            public int ColumnNumber => 0;
+
+            public string File => string.Empty;
+
+            public string Line => string.Empty;
+
+            public int LineNumber => 0;
+
+            public int Offset => 0;
+
+            public string GetFullScript() => string.Empty;
+        }
+    }
+}

--- a/src/PSLambda/ExpressionExtensions.cs
+++ b/src/PSLambda/ExpressionExtensions.cs
@@ -50,12 +50,12 @@ namespace PSLambda
             }
             catch (ArgumentException e)
             {
-                visitor.ReportParseError(ast.Extent, e);
+                visitor.Errors.ReportParseError(ast.Extent, e);
                 return Expression.Empty();
             }
             catch (InvalidOperationException e)
             {
-                visitor.ReportParseError(ast.Extent, e);
+                visitor.Errors.ReportParseError(ast.Extent, e);
                 return Expression.Empty();
             }
         }

--- a/src/PSLambda/IParseErrorWriter.cs
+++ b/src/PSLambda/IParseErrorWriter.cs
@@ -1,0 +1,38 @@
+using System.Management.Automation.Language;
+
+namespace PSLambda
+{
+    /// <summary>
+    /// Provides uniform writing and management of <see cref="ParseError" /> objects.
+    /// </summary>
+    internal interface IParseErrorWriter
+    {
+        /// <summary>
+        /// Reports a <see cref="ParseError" />. Handling of the <see cref="ParseError" />
+        /// may defer between implementations.
+        /// </summary>
+        /// <param name="extent">
+        /// The <see cref="IScriptExtent" /> of the error being reported.
+        /// </param>
+        /// <param name="id">The id of the error.</param>
+        /// <param name="message">
+        /// The message to display in the <see cref="System.Management.Automation.ParseException" />
+        /// when parsing is completed.
+        /// </param>
+        void ReportParseError(
+            IScriptExtent extent,
+            string id,
+            string message);
+
+        /// <summary>
+        /// Throws if the error limit has been hit. Error limit may vary
+        /// between implementations.
+        /// </summary>
+        void ThrowIfErrorLimitHit();
+
+        /// <summary>
+        /// Throws if any error has been reported.
+        /// </summary>
+        void ThrowIfAnyErrors();
+    }
+}

--- a/src/PSLambda/MemberBinder.cs
+++ b/src/PSLambda/MemberBinder.cs
@@ -1,0 +1,678 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace PSLambda
+{
+    /// <summary>
+    /// Provides member binding for method invocation expressions.
+    /// </summary>
+    internal class MemberBinder
+    {
+        private static readonly PSVariable[] s_emptyVariables = new PSVariable[0];
+
+        private static readonly ParameterAst[] s_emptyParameterAsts = new ParameterAst[0];
+
+        private readonly BindingFlags _instanceFlags;
+
+        private readonly BindingFlags _staticFlags;
+
+        private readonly string[] _namespaces;
+
+        private MethodInfo[] _extensionMethods;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemberBinder" /> class.
+        /// </summary>
+        /// <param name="accessFlags">
+        /// The <see cref="BindingFlags" /> to use while resolving members. Only pass
+        /// access modifiers (e.g. <see cref="BindingFlags.Public" /> or
+        /// <see cref="BindingFlags.NonPublic" />.</param>
+        /// <param name="namespaces">The namespaces to resolve extension methods in.</param>
+        public MemberBinder(BindingFlags accessFlags, string[] namespaces)
+        {
+            _instanceFlags = accessFlags | BindingFlags.IgnoreCase | BindingFlags.Instance;
+            _staticFlags = accessFlags | BindingFlags.IgnoreCase | BindingFlags.Static;
+            _namespaces = new string[namespaces.Length];
+            namespaces.CopyTo(_namespaces, 0);
+        }
+
+        /// <summary>
+        /// Determines the correct member for an expression and creates a
+        /// <see cref="Expression" /> representing it's invocation.
+        /// </summary>
+        /// <param name="visitor">The <see cref="CompileVisitor" /> requesting the bind.</param>
+        /// <param name="instance">The instance <see cref="Expression" /> for the invocation.</param>
+        /// <param name="name">The member name to use while resolving the method.</param>
+        /// <param name="arguments">The arguments to use while resolving the method.</param>
+        /// <param name="genericArguments">The generic arguments to use while resolving the method.</param>
+        /// <returns>
+        /// A <see cref="BindingResult" /> that either contains the
+        /// <see cref="Expression" /> or the <see cref="ArgumentException" /> and
+        /// error ID.
+        /// </returns>
+        internal BindingResult BindMethod(
+            CompileVisitor visitor,
+            Expression instance,
+            string name,
+            Ast[] arguments,
+            Type[] genericArguments)
+        {
+            return BindMethod(
+                visitor,
+                instance.Type,
+                name,
+                arguments,
+                instance,
+                genericArguments);
+        }
+
+        /// <summary>
+        /// Determines the correct member for an expression and creates a
+        /// <see cref="Expression" /> representing it's invocation.
+        /// </summary>
+        /// <param name="visitor">The <see cref="CompileVisitor" /> requesting the bind.</param>
+        /// <param name="sourceType">The source <see cref="Type" /> for the invocation.</param>
+        /// <param name="name">The member name to use while resolving the method.</param>
+        /// <param name="arguments">The arguments to use while resolving the method.</param>
+        /// <param name="genericArguments">The generic arguments to use while resolving the method.</param>
+        /// <returns>
+        /// A <see cref="BindingResult" /> that either contains the
+        /// <see cref="Expression" /> or the <see cref="ArgumentException" /> and
+        /// error ID.
+        /// </returns>
+        internal BindingResult BindMethod(
+            CompileVisitor visitor,
+            Type sourceType,
+            string name,
+            Ast[] arguments,
+            Type[] genericArguments)
+        {
+            return BindMethod(
+                visitor,
+                sourceType,
+                name,
+                arguments,
+                null,
+                genericArguments);
+        }
+
+        private BindingResult BindMethod(
+            CompileVisitor visitor,
+            Type sourceType,
+            string name,
+            Ast[] arguments,
+            Expression instance,
+            Type[] genericArguments)
+        {
+            var methodArgs = new MethodArgument[arguments.Length];
+            for (var i = 0; i < methodArgs.Length; i++)
+            {
+                methodArgs[i] = (MethodArgument)arguments[i];
+            }
+
+            var didFindName = false;
+            var isInstance = instance != null;
+            var methods = sourceType.GetMethods(isInstance ? _instanceFlags : _staticFlags);
+            MethodInfo boundMethod;
+            BindingResult bindingResult = default(BindingResult);
+            for (var i = 0; i < methods.Length; i++)
+            {
+                if (!methods[i].Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!didFindName)
+                {
+                    didFindName = true;
+                }
+
+                if (genericArguments.Length > 0 &&
+                    (!methods[i].IsGenericMethod ||
+                    !AreGenericArgumentsValid(methods[i], genericArguments)))
+                {
+                        continue;
+                }
+
+                if (genericArguments.Length > 0)
+                {
+                    methods[i] = methods[i].MakeGenericMethod(genericArguments);
+                }
+
+                if (ShouldBind(methods[i], methodArgs, visitor, out boundMethod))
+                {
+                    var expressions = new Expression[methodArgs.Length];
+                    for (var j = 0; j < methodArgs.Length; j++)
+                    {
+                        expressions[j] = methodArgs[j].Expression;
+                    }
+
+                    bindingResult.Expression = Expression.Call(instance, boundMethod, expressions);
+                    return bindingResult;
+                }
+            }
+
+            if (!isInstance)
+            {
+                bindingResult.Reason = new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ErrorStrings.NoMemberArgumentMatch,
+                        sourceType.FullName,
+                        name));
+                bindingResult.Id = nameof(ErrorStrings.NoMemberArgumentMatch);
+                return bindingResult;
+            }
+
+            var extensionArgs = new MethodArgument[methodArgs.Length + 1];
+            extensionArgs[0] = (MethodArgument)instance;
+            for (var i = 1; i < extensionArgs.Length; i++)
+            {
+                extensionArgs[i] = methodArgs[i - 1];
+            }
+
+            methods = GetExtensionMethods();
+            for (var i = 0; i < methods.Length; i++)
+            {
+                if (!methods[i].Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!didFindName)
+                {
+                    didFindName = true;
+                }
+
+                if (genericArguments.Length > 0 &&
+                    (!methods[i].IsGenericMethod ||
+                    !AreGenericArgumentsValid(methods[i], genericArguments)))
+                {
+                        continue;
+                }
+
+                if (genericArguments.Length > 0)
+                {
+                    methods[i] = methods[i].MakeGenericMethod(genericArguments);
+                }
+
+                if (ShouldBind(methods[i], extensionArgs, visitor, out boundMethod))
+                {
+                    var expressions = new Expression[extensionArgs.Length];
+                    for (var j = 0; j < extensionArgs.Length; j++)
+                    {
+                        expressions[j] = extensionArgs[j].Expression;
+                    }
+
+                    bindingResult.Expression = Expression.Call(boundMethod, expressions);
+                    return bindingResult;
+                }
+            }
+
+            if (!didFindName)
+            {
+                bindingResult.Reason =
+                    new ArgumentException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            ErrorStrings.NoMemberNameMatch,
+                            sourceType.FullName,
+                            name));
+
+                bindingResult.Id = nameof(ErrorStrings.NoMemberNameMatch);
+                return bindingResult;
+            }
+
+            bindingResult.Reason = new ArgumentException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ErrorStrings.NoMemberArgumentMatch,
+                    sourceType.FullName,
+                    name));
+            bindingResult.Id = nameof(ErrorStrings.NoMemberArgumentMatch);
+            return bindingResult;
+        }
+
+        private MethodInfo[] GetExtensionMethods()
+        {
+            if (_extensionMethods != null)
+            {
+                return _extensionMethods;
+            }
+
+            var extensionMethods = new List<MethodInfo>();
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                foreach (var module in assembly.GetModules())
+                {
+                    foreach (var type in module.GetTypes())
+                    {
+                        if (string.IsNullOrEmpty(type.Namespace))
+                        {
+                            continue;
+                        }
+
+                        if (!_namespaces.Any(ns => ns.Equals(type.Namespace, StringComparison.InvariantCultureIgnoreCase)))
+                        {
+                            continue;
+                        }
+
+                        foreach (var method in type.GetMethods(_staticFlags))
+                        {
+                            if (method.IsDefined(typeof(ExtensionAttribute), inherit: false))
+                            {
+                                extensionMethods.Add(method);
+                            }
+                        }
+                    }
+                }
+            }
+
+            _extensionMethods = extensionMethods.ToArray();
+            return _extensionMethods;
+        }
+
+        private bool AreGenericArgumentsValid(MethodInfo method, Type[] genericArguments)
+        {
+            var genericParameters = method.GetGenericArguments();
+            if (genericParameters.Length != genericArguments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < genericParameters.Length; i++)
+            {
+                var constraints = genericParameters[i].GetGenericParameterConstraints();
+                for (var j = 0; j < constraints.Length; j++)
+                {
+                    if (!constraints[j].IsAssignableFrom(genericParameters[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private bool ShouldBind(
+            MethodInfo method,
+            MethodArgument[] arguments,
+            CompileVisitor visitor,
+            out MethodInfo resolvedMethod)
+        {
+            var parameters = method.GetParameters();
+            if (parameters.Length != arguments.Length)
+            {
+                resolvedMethod = null;
+                return false;
+            }
+
+            BindingStatus status;
+            status._map = new Dictionary<Type, Type>();
+            status._hasGenericParams = method.IsGenericMethod;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (arguments[i].Ast != null &&
+                    (arguments[i].Ast is ScriptBlockExpressionAst ||
+                    arguments[i].Ast is ScriptBlockAst))
+                {
+                    if (!(typeof(Delegate).IsAssignableFrom(parameters[i].ParameterType) ||
+                        typeof(LambdaExpression).IsAssignableFrom(parameters[i].ParameterType)))
+                    {
+                        resolvedMethod = null;
+                        return false;
+                    }
+
+                    if (status.IsDelegateMatch(parameters[i].ParameterType, arguments[i], visitor))
+                    {
+                        continue;
+                    }
+
+                    resolvedMethod = null;
+                    return false;
+                }
+
+                if (arguments[i].Expression == null)
+                {
+                    arguments[i].Expression = arguments[i].Ast.Compile(visitor);
+                }
+
+                if (!status.IsTypeMatch(parameters[i].ParameterType, arguments[i].Expression.Type))
+                {
+                    resolvedMethod = null;
+                    return false;
+                }
+            }
+
+            if (!status._hasGenericParams || !method.IsGenericMethodDefinition)
+            {
+                resolvedMethod = method;
+                return true;
+            }
+
+            var genericParameters = method.GetGenericArguments();
+            var genericArguments = new Type[genericParameters.Length];
+            for (var i = 0; i < genericParameters.Length; i++)
+            {
+                genericArguments[i] = status._map[genericParameters[i]];
+            }
+
+            resolvedMethod = method.MakeGenericMethod(genericArguments);
+            return true;
+        }
+
+        /// <summary>
+        /// Represents the result of a method binding attempt.
+        /// </summary>
+        internal struct BindingResult
+        {
+            /// <summary>
+            /// The generated <see cref="Expression" />. Can be <see langkeyword="null" />
+            /// if the binding attempt was unsuccessful.
+            /// </summary>
+            internal Expression Expression;
+
+            /// <summary>
+            /// The <see cref="Exception" /> that describes the binding failure. Can be
+            /// <see langkeyword="null" /> if the binding was successful.
+            /// </summary>
+            internal Exception Reason;
+
+            /// <summary>
+            /// The ID that should be attached to the <see cref="ParseException" />. Can
+            /// be <see langkeyword="null" /> if the binding attempt was successful.
+            /// </summary>
+            internal string Id;
+        }
+
+        private struct BindingStatus
+        {
+            internal Dictionary<Type, Type> _map;
+
+            internal bool _hasGenericParams;
+
+            internal bool IsTypeMatch(Type parameterType, Type argumentType)
+            {
+                if (parameterType.IsByRef)
+                {
+                    parameterType = parameterType.GetElementType();
+                }
+
+                if (parameterType.IsAssignableFrom(argumentType))
+                {
+                    return true;
+                }
+
+                if (!_hasGenericParams)
+                {
+                    return false;
+                }
+
+                if (argumentType.IsArray &&
+                    parameterType.IsGenericType &&
+                    parameterType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    argumentType = typeof(IEnumerable<>).MakeGenericType(
+                        argumentType.GetElementType());
+                }
+
+                if (parameterType.IsPointer != argumentType.IsPointer)
+                {
+                    return false;
+                }
+
+                if (parameterType.HasElementType && parameterType.HasElementType)
+                {
+                    parameterType = parameterType.GetElementType();
+                    argumentType = argumentType.GetElementType();
+                }
+
+                if (parameterType.IsGenericType && parameterType.IsGenericType)
+                {
+                    var parameterGenerics = parameterType.GetGenericArguments();
+                    var argumentGenerics = argumentType.GetGenericArguments();
+
+                    if (parameterGenerics.Length != argumentGenerics.Length)
+                    {
+                        return false;
+                    }
+
+                    for (var i = 0; i < parameterGenerics.Length; i++)
+                    {
+                        if (!IsTypeMatch(parameterGenerics[i], argumentGenerics[i]))
+                        {
+                            return false;
+                        }
+                    }
+
+                    var constructedParameterType = parameterType
+                        .GetGenericTypeDefinition()
+                        .MakeGenericType(argumentGenerics);
+
+                    return constructedParameterType.IsAssignableFrom(argumentType);
+                }
+
+                if (!parameterType.IsGenericParameter)
+                {
+                    return false;
+                }
+
+                if (_map.TryGetValue(parameterType, out Type existingResolvedType))
+                {
+                    return existingResolvedType.IsAssignableFrom(argumentType);
+                }
+
+                foreach (var constraint in parameterType.GetGenericParameterConstraints())
+                {
+                    if (!constraint.IsAssignableFrom(argumentType))
+                    {
+                        return false;
+                    }
+                }
+
+                _map.Add(parameterType, argumentType);
+                return true;
+            }
+
+            internal bool IsDelegateMatch(Type parameterType, MethodArgument argument, CompileVisitor visitor)
+            {
+                ScriptBlockAst sbAst;
+                if (argument.Ast is ScriptBlockExpressionAst sbExpression)
+                {
+                    sbAst = (ScriptBlockAst)sbExpression.ScriptBlock.Visit(
+                        new DelegateSyntaxVisitor(visitor.Errors));
+                }
+                else
+                {
+                    sbAst = (ScriptBlockAst)((ScriptBlockAst)argument.Ast).Visit(
+                        new DelegateSyntaxVisitor(visitor.Errors));
+                }
+
+                argument.Ast = sbAst;
+                var parameterMethod = parameterType.GetMethod(Strings.DelegateInvokeMethodName);
+                if (parameterMethod == null && typeof(Expression).IsAssignableFrom(parameterType))
+                {
+                    parameterMethod = parameterType
+                        .GetGenericArguments()[0]
+                        .GetMethod(Strings.DelegateInvokeMethodName);
+                }
+
+                var astHasExplicitReturn = ExplicitReturnVisitor.TryFindExplicitReturn(
+                    sbAst,
+                    out PipelineBaseAst returnValue);
+
+                if (astHasExplicitReturn)
+                {
+                    if (parameterMethod.ReturnType == typeof(void) &&
+                        returnValue != null)
+                    {
+                        return false;
+                    }
+                }
+
+                var parameterParameters = parameterMethod.GetParameters();
+                ParameterAst[] sbParameters;
+                if (sbAst.ParamBlock != null)
+                {
+                    sbParameters = new ParameterAst[sbAst.ParamBlock.Parameters.Count];
+                    for (var i = 0; i < sbParameters.Length; i++)
+                    {
+                        sbParameters[i] = sbAst.ParamBlock.Parameters[i];
+                    }
+                }
+                else
+                {
+                    sbParameters = s_emptyParameterAsts;
+                }
+
+                if (parameterParameters.Length != sbParameters.Length)
+                {
+                    return false;
+                }
+
+                var expectedParameterTypes = new Type[parameterParameters.Length];
+                for (var i = 0; i < parameterParameters.Length; i++)
+                {
+                    if (parameterParameters[i].ParameterType.IsGenericParameter)
+                    {
+                        if (_map.TryGetValue(parameterParameters[i].ParameterType, out Type resolvedType))
+                        {
+                            expectedParameterTypes[i] = resolvedType;
+                            continue;
+                        }
+
+                        // TODO: Check if parameter is strongly typed in the AST and use that to
+                        //       resolve the targ.
+                        return false;
+                    }
+
+                    expectedParameterTypes[i] = parameterParameters[i].ParameterType;
+                }
+
+                var expectedReturnType = parameterMethod.ReturnType.IsGenericParameter
+                    ? null
+                    : parameterMethod.ReturnType;
+
+                if (expectedReturnType == null)
+                {
+                    _map.TryGetValue(parameterMethod.ReturnType, out expectedReturnType);
+                }
+
+                var oldErrorWriter = visitor.Errors;
+                try
+                {
+                    visitor.Errors = ParseErrorWriter.CreateNull();
+                    argument.Expression = visitor.CompileAstImpl(
+                        sbAst,
+                        s_emptyVariables,
+                        expectedParameterTypes,
+                        expectedReturnType,
+                        null);
+                }
+                catch (Exception)
+                {
+                    // TODO: Better reporting here if all method resolution fails.
+                    return false;
+                }
+                finally
+                {
+                    visitor.Errors = oldErrorWriter;
+                }
+
+                if (parameterMethod.ReturnType.IsGenericParameter &&
+                    !_map.ContainsKey(parameterMethod.ReturnType))
+                {
+                    _map.Add(parameterMethod.ReturnType, ((LambdaExpression)argument.Expression).ReturnType);
+                }
+
+                if (parameterType.IsGenericType)
+                {
+                    var genericParameters = parameterType.GetGenericArguments();
+                    var newGenericParameters = new Type[genericParameters.Length];
+                    for (var i = 0; i < genericParameters.Length; i++)
+                    {
+                        if (genericParameters[i].IsGenericParameter)
+                        {
+                            _map.TryGetValue(genericParameters[i], out Type resolvedType);
+                            newGenericParameters[i] = resolvedType;
+                            continue;
+                        }
+
+                        newGenericParameters[i] = genericParameters[i];
+                    }
+
+                    parameterType = parameterType
+                        .GetGenericTypeDefinition()
+                        .MakeGenericType(newGenericParameters);
+                }
+
+                argument.Expression = Expression.Lambda(
+                    parameterType,
+                    ((LambdaExpression)argument.Expression).Body,
+                    ((LambdaExpression)argument.Expression).Parameters);
+                return true;
+            }
+        }
+
+        private class MethodArgument
+        {
+            internal Ast Ast;
+
+            internal Expression Expression;
+
+            public static explicit operator Expression(MethodArgument argument)
+            {
+                return argument.Expression;
+            }
+
+            public static explicit operator MethodArgument(Ast ast)
+            {
+                var argument = new MethodArgument();
+                argument.Ast = ast;
+                return argument;
+            }
+
+            public static explicit operator MethodArgument(Expression expression)
+            {
+                var argument = new MethodArgument();
+                argument.Expression = expression;
+                return argument;
+            }
+        }
+
+        private class ExplicitReturnVisitor : AstVisitor
+        {
+            private bool _wasFound;
+
+            private PipelineBaseAst _returnPipeline;
+
+            public override AstVisitAction VisitInvokeMemberExpression(InvokeMemberExpressionAst methodCallAst)
+            {
+                return AstVisitAction.SkipChildren;
+            }
+
+            public override AstVisitAction VisitReturnStatement(ReturnStatementAst returnStatementAst)
+            {
+                _wasFound = true;
+                _returnPipeline = returnStatementAst.Pipeline;
+                return AstVisitAction.StopVisit;
+            }
+
+            internal static bool TryFindExplicitReturn(Ast ast, out PipelineBaseAst returnValue)
+            {
+                var visitor = new ExplicitReturnVisitor();
+                ast.Visit(visitor);
+                returnValue = visitor._returnPipeline;
+                return visitor._wasFound;
+            }
+        }
+    }
+}

--- a/src/PSLambda/ParseErrorWriter.cs
+++ b/src/PSLambda/ParseErrorWriter.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace PSLambda
+{
+    /// <summary>
+    /// Provides uniform writing and management of <see cref="ParseError" /> objects.
+    /// </summary>
+    internal abstract class ParseErrorWriter : IParseErrorWriter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParseErrorWriter" /> class.
+        /// </summary>
+        protected ParseErrorWriter()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the default <see cref="ParseErrorWriter" />. This
+        /// error writer will report full error messages and will throw after a maximum
+        /// of three errors.
+        /// </summary>
+        /// <returns>The defualt <see cref="ParseErrorWriter" />.</returns>
+        public static ParseErrorWriter CreateDefault() => new DefaultParseErrorWriter();
+
+        /// <summary>
+        /// Creates an instance of the null <see cref="ParseErrorWriter" />. This
+        /// error writer will not report any error messages and will throw immediately
+        /// after the first error has been reported.
+        /// </summary>
+        /// <returns>The null <see cref="ParseErrorWriter" />.</returns>
+        public static ParseErrorWriter CreateNull() => new NullParseErrorWriter();
+
+        /// <summary>
+        /// Reports a <see cref="ParseError" />. Handling of the <see cref="ParseError" />
+        /// may defer between implementations.
+        /// </summary>
+        /// <param name="extent">
+        /// The <see cref="IScriptExtent" /> of the error being reported.
+        /// </param>
+        /// <param name="id">The id of the error.</param>
+        /// <param name="message">
+        /// The message to display in the <see cref="System.Management.Automation.ParseException" />
+        /// when parsing is completed.
+        /// </param>
+        public virtual void ReportParseError(IScriptExtent extent, string id, string message)
+        {
+        }
+
+        /// <summary>
+        /// Throws if the error limit has been hit. Error limit may vary
+        /// between implementations.
+        /// </summary>
+        public virtual void ThrowIfErrorLimitHit()
+        {
+        }
+
+        /// <summary>
+        /// Throws if any error has been reported.
+        /// </summary>
+        public virtual void ThrowIfAnyErrors()
+        {
+        }
+
+        private class NullParseErrorWriter : ParseErrorWriter
+        {
+            private int _errorCount;
+
+            public override void ReportParseError(IScriptExtent extent, string id, string message)
+            {
+                _errorCount++;
+                throw new ParseException();
+            }
+
+            public override void ThrowIfAnyErrors()
+            {
+                if (_errorCount > 0)
+                {
+                    throw new ParseException();
+                }
+            }
+
+            public override void ThrowIfErrorLimitHit()
+            {
+                if (_errorCount > 0)
+                {
+                    throw new ParseException();
+                }
+            }
+        }
+
+        private class DefaultParseErrorWriter : ParseErrorWriter
+        {
+            private const int ErrorLimit = 3;
+
+            private readonly List<ParseError> _errors = new List<ParseError>();
+
+            public override void ReportParseError(IScriptExtent extent, string id, string message)
+            {
+                _errors.Add(
+                    new ParseError(
+                        extent,
+                        id,
+                        message));
+
+                ThrowIfErrorLimitHit();
+            }
+
+            public override void ThrowIfErrorLimitHit()
+            {
+                if (_errors.Count < ErrorLimit)
+                {
+                    return;
+                }
+
+                throw new ParseException(_errors.ToArray());
+            }
+
+            public override void ThrowIfAnyErrors()
+            {
+                if (_errors.Count < 1)
+                {
+                    return;
+                }
+
+                throw new ParseException(_errors.ToArray());
+            }
+        }
+    }
+}

--- a/src/PSLambda/ParseWriterExtensions.cs
+++ b/src/PSLambda/ParseWriterExtensions.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Globalization;
+using System.Management.Automation.Language;
+
+namespace PSLambda
+{
+    /// <summary>
+    /// Provides utility methods for reporting specific types of
+    /// <see cref="ParseError" /> objects.
+    /// </summary>
+    internal static class ParseWriterExtensions
+    {
+        /// <summary>
+        /// Generate a <see cref="ParseError" /> citing an unsupported <see cref="Ast" /> type.
+        /// </summary>
+        /// <param name="writer">The <see cref="IParseErrorWriter" /> that should issue the report.</param>
+        /// <param name="ast">The <see cref="Ast" /> that is not supported.</param>
+        internal static void ReportNotSupportedAstType(
+            this IParseErrorWriter writer,
+            Ast ast)
+        {
+            writer.ReportNotSupported(
+                ast.Extent,
+                ast.GetType().Name,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ErrorStrings.AstNotSupported,
+                    ast.GetType().Name));
+        }
+
+        /// <summary>
+        /// Generate a <see cref="ParseError" /> citing an unsupported element.
+        /// </summary>
+        /// <param name="writer">The <see cref="IParseErrorWriter" /> that should issue the report.</param>
+        /// <param name="extent">The <see cref="IScriptExtent" /> of the unsupported element.</param>
+        /// <param name="id">The ID to be shown in the <see cref="ParseError" />.</param>
+        /// <param name="message">The message to be shown in the <see cref="ParseError" />.</param>
+        internal static void ReportNotSupported(
+            this IParseErrorWriter writer,
+            IScriptExtent extent,
+            string id,
+            string message)
+        {
+            writer.ReportParseError(
+                extent,
+                nameof(ErrorStrings.ElementNotSupported),
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ErrorStrings.ElementNotSupported,
+                    message));
+        }
+
+        /// <summary>
+        /// Generate a <see cref="ParseError" /> citing a missing element.
+        /// </summary>
+        /// <param name="writer">The <see cref="IParseErrorWriter" /> that should issue the report.</param>
+        /// <param name="extent">The <see cref="IScriptExtent" /> of the missing element.</param>
+        /// <param name="id">The ID to be shown in the <see cref="ParseError" />.</param>
+        /// <param name="message">The message to be shown in the <see cref="ParseError" />.</param>
+        internal static void ReportMissing(
+            this IParseErrorWriter writer,
+            IScriptExtent extent,
+            string id,
+            string message)
+        {
+            writer.ReportParseError(
+                extent,
+                nameof(ErrorStrings.ElementMissing),
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ErrorStrings.ElementMissing,
+                    message));
+        }
+
+        /// <summary>
+        /// Generate a <see cref="ParseError" />.
+        /// </summary>
+        /// <param name="writer">The <see cref="IParseErrorWriter" /> that should issue the report.</param>
+        /// <param name="extent">The <see cref="IScriptExtent" /> of element in error.</param>
+        /// <param name="id">The ID to be shown in the <see cref="ParseError" />.</param>
+        /// <param name="message">The message to be shown in the <see cref="ParseError" />.</param>
+        internal static void ReportParseError(
+            this IParseErrorWriter writer,
+            IScriptExtent extent,
+            string id = nameof(ErrorStrings.CompileTimeParseError),
+            string message = "")
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                message = ErrorStrings.CompileTimeParseError;
+            }
+
+            writer.ReportParseError(extent, id, message);
+        }
+
+        /// <summary>
+        /// Generate a <see cref="ParseError" />.
+        /// </summary>
+        /// <param name="writer">The <see cref="IParseErrorWriter" /> that should issue the report.</param>
+        /// <param name="extent">The <see cref="IScriptExtent" /> of element in error.</param>
+        /// <param name="exception">
+        /// The exception housing the message to be shown in the <see cref="ParseError" />.
+        /// </param>
+        /// <param name="id">The ID to be shown in the <see cref="ParseError" />.</param>
+        internal static void ReportParseError(
+            this IParseErrorWriter writer,
+            IScriptExtent extent,
+            Exception exception,
+            string id = "")
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                id = exception.GetType().Name;
+            }
+
+            writer.ReportParseError(
+                extent,
+                id,
+                exception.Message);
+        }
+
+        /// <summary>
+        /// Generate a <see cref="ParseError" />.
+        /// </summary>
+        /// <param name="writer">The <see cref="IParseErrorWriter" /> that should issue the report.</param>
+        /// <param name="extent">The <see cref="IScriptExtent" /> of element in error.</param>
+        internal static void ReportNonConstantTypeAs(
+            this IParseErrorWriter writer,
+            IScriptExtent extent)
+        {
+            writer.ReportNotSupported(
+                extent,
+                nameof(ErrorStrings.NonConstantTypeAs),
+                ErrorStrings.NonConstantTypeAs);
+        }
+    }
+}

--- a/src/PSLambda/resources/ErrorStrings.resx
+++ b/src/PSLambda/resources/ErrorStrings.resx
@@ -162,4 +162,10 @@
   <data name="MissingWithElements" xml:space="preserve">
     <value>The with statement requires both a expression that evaluates to a System.IDisposable object and ScriptBlock expression as arguments.</value>
   </data>
+  <data name="NoMemberNameMatch" xml:space="preserve">
+    <value>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found.</value>
+  </data>
+  <data name="NoMemberArgumentMatch" xml:space="preserve">
+    <value>'{0}' does not contain a definition for a method named '{1}' that takes the specified arguments.</value>
+  </data>
 </root>

--- a/test/MethodResolution.Tests.ps1
+++ b/test/MethodResolution.Tests.ps1
@@ -96,7 +96,6 @@ Describe 'Method resolution tests' {
             "contain a definition for a method named 'WriteLine' that takes the " +
             "specified arguments."
 
-        { New-PSDelegate { [Collections.Generic.List[int]]::new(0..10).ConvertAll('invalid') } } |
-            Should -Throw $expectedMsg
+        { New-PSDelegate { $Host.UI.WriteLine(10) }} | Should -Throw $expectedMsg
     }
 }

--- a/test/MethodResolution.Tests.ps1
+++ b/test/MethodResolution.Tests.ps1
@@ -90,5 +90,13 @@ Describe 'Method resolution tests' {
             "named 'Compare' that takes the specified arguments."
 
         { New-PSDelegate { [string]::Compare() }} | Should -Throw $expectedMsg
+
+        $expectedMsg =
+            "'System.Management.Automation.Host.PSHostUserInterface' does not " +
+            "contain a definition for a method named 'WriteLine' that takes the " +
+            "specified arguments."
+
+        { New-PSDelegate { [Collections.Generic.List[int]]::new(0..10).ConvertAll('invalid') } } |
+            Should -Throw $expectedMsg
     }
 }

--- a/test/MethodResolution.Tests.ps1
+++ b/test/MethodResolution.Tests.ps1
@@ -1,0 +1,94 @@
+using namespace System
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+$moduleName = 'PSLambda'
+$manifestPath = "$PSScriptRoot\..\Release\$moduleName\*\$moduleName.psd1"
+
+Import-Module $manifestPath -Force
+
+Describe 'Method resolution tests' {
+    It 'can resolve generic parameters from usage' {
+        $delegate = New-PSDelegate {
+            $ExecutionContext.InvokeProvider.ChildItem.Get('function:', $true).
+                Select{ $pso => $pso.BaseObject }.
+                OfType([g[System.Management.Automation.FunctionInfo]]).
+                FirstOrDefault{ $f => $f.Name.Equals('TabExpansion2') }
+        }
+
+        $delegate.Invoke().Name | Should -Be TabExpansion2
+    }
+
+    It 'can resolve extension methods other than Linq' {
+        $sb = [scriptblock]::Create('
+            using namespace System.Threading.Tasks
+
+            New-PSDelegate {
+                $task = [Task]::FromResult([Task]::Run{ return "testing" })
+                return $task.Unwrap()
+            }')
+
+        $delegate = $sb.Invoke()
+        $delegate.Invoke().GetAwaiter().GetResult() | Should -Be testing
+    }
+
+    It 'can pass variables by ref' {
+        $delegate = New-PSDelegate {
+            [Token[]] $tokens = $null
+            [ParseError[]] $errors = $null
+            $ast = [Parser]::ParseInput('{', $tokens, $errors)
+            return [Tuple]::Create($ast, $tokens, $errors)
+        }
+
+        $result = $delegate.Invoke()
+        $result.Item1 | Should -BeOfType System.Management.Automation.Language.Ast
+        $result.Item2.GetType() | Should -Be ([Token[]])
+        $result.Item2.Length | Should -Be 2
+        $result.Item3.GetType() | Should -Be ([ParseError[]])
+        $result.Item3.Length | Should -Be 1
+    }
+
+    It 'can convert delegates to other than Func/Action ' {
+        $delegate = New-PSDelegate {
+            $list = [System.Collections.Generic.List[int]]::new(0..10)
+            return $list.ConvertAll{ $i => $i.ToString() }
+        }
+
+        $delegate.Invoke().GetType() | Should -Be ([System.Collections.Generic.List[string]])
+    }
+
+    It 'can resolve many generic parameters' {
+        $delegate = New-PSDelegate {
+            [Tuple]::Create(
+                10,
+                [Exception]::new(),
+                'string',
+                $Host,
+                [runspace]::DefaultRunspace,
+                [ConsoleColor]::Black,
+                @{}).
+                ToValueTuple()
+        }
+
+        $delegate.Invoke().GetType() |
+            Should -Be (
+                [ValueTuple[int, exception, string, Host.PSHost, runspace, ConsoleColor, hashtable]])
+    }
+
+    It 'throws the correct message when a member does not exist' {
+        $expectedMsg =
+            "'System.String' does not contain a definition for 'RandomName' " +
+            "and no extension method 'RandomName' accepting a first argument " +
+            "of type 'System.String' could be found."
+
+        { New-PSDelegate { ''.RandomName() }} | Should -Throw $expectedMsg
+    }
+
+    It 'throws the correct message when method arguments do not match' {
+        $expectedMsg =
+            "'System.String' does not contain a definition for a method " +
+            "named 'Compare' that takes the specified arguments."
+
+        { New-PSDelegate { [string]::Compare() }} | Should -Throw $expectedMsg
+    }
+}


### PR DESCRIPTION
This change adds a custom method binder that allows for more
complex method resolution, including the following improvements.

- Infer generic method parameters from usage

- Resolve extension methods from using statements. The 'System.Linq'
  namespace is included by default.

- Better detection of the proper expression type for script blocks in
  method arguments

In addition, the rules for the anonymous method syntactic sugar has been
relaxed to allow parameters without parenthesis or a script block.

Resolves #2, #3