### PR TITLE
Add lock keyword

### DIFF
--- a/src/PSLambda/Commands/CommandService.cs
+++ b/src/PSLambda/Commands/CommandService.cs
@@ -20,6 +20,7 @@ namespace PSLambda.Commands
             RegisterCommand(new DefaultCommand());
             RegisterCommand(new WithCommand());
             RegisterCommand(new GenericCommand());
+            RegisterCommand(new LockCommand());
         }
 
         /// <summary>

--- a/src/PSLambda/Commands/LockCommand.cs
+++ b/src/PSLambda/Commands/LockCommand.cs
@@ -1,0 +1,54 @@
+using System.Linq.Expressions;
+using System.Management.Automation.Language;
+
+namespace PSLambda.Commands
+{
+    /// <summary>
+    /// Provides handling for the "lock" custom command.
+    /// </summary>
+    internal class LockCommand : ObjectAndBodyCommandHandler
+    {
+        /// <summary>
+        /// Gets the name of the command.
+        /// </summary>
+        public override string CommandName { get; } = "lock";
+
+        /// <summary>
+        /// Creates a Linq expression for a <see cref="CommandAst" /> representing
+        /// the "lock" command.
+        /// </summary>
+        /// <param name="commandAst">The AST to convert.</param>
+        /// <param name="targetAst">The AST containing the target of the keyword.</param>
+        /// <param name="bodyAst">The AST containing the body of the keyword.</param>
+        /// <param name="visitor">The <see cref="CompileVisitor" /> requesting the expression.</param>
+        /// <returns>An expression representing the command.</returns>
+        protected override Expression ProcessObjectAndBody(
+            CommandAst commandAst,
+            CommandElementAst targetAst,
+            ScriptBlockExpressionAst bodyAst,
+            CompileVisitor visitor)
+        {
+            var lockVar = Expression.Variable(typeof(object));
+            var lockTakenVar = Expression.Variable(typeof(bool));
+            return visitor.NewBlock(() =>
+                Expression.Block(
+                    typeof(void),
+                    new[] { lockVar, lockTakenVar },
+                    Expression.Call(
+                        ReflectionCache.Monitor_Enter,
+                        Expression.Assign(
+                            lockVar,
+                            Expression.Convert(
+                                targetAst.Compile(visitor),
+                                typeof(object))),
+                        lockTakenVar),
+                    Expression.TryFinally(
+                        bodyAst.ScriptBlock.EndBlock.Compile(visitor),
+                        Expression.IfThen(
+                            lockTakenVar,
+                            Expression.Call(
+                                ReflectionCache.Monitor_Exit,
+                                lockVar)))));
+        }
+    }
+}

--- a/src/PSLambda/Commands/ObjectAndBodyCommandHandler.cs
+++ b/src/PSLambda/Commands/ObjectAndBodyCommandHandler.cs
@@ -1,0 +1,74 @@
+using System.Globalization;
+using System.Linq.Expressions;
+using System.Management.Automation.Language;
+
+namespace PSLambda.Commands
+{
+    /// <summary>
+    /// Provides a base for commands that follow the format of
+    /// `commandName ($objectTarget) { body }`
+    /// </summary>
+    internal abstract class ObjectAndBodyCommandHandler : ICommandHandler
+    {
+        /// <summary>
+        /// Gets the name of the command.
+        /// </summary>
+        public abstract string CommandName { get; }
+
+        /// <summary>
+        /// Creates a Linq expression for a <see cref="CommandAst" /> representing
+        /// a custom command.
+        /// </summary>
+        /// <param name="commandAst">The AST to convert.</param>
+        /// <param name="visitor">The <see cref="CompileVisitor" /> requesting the expression.</param>
+        /// <returns>An expression representing the command.</returns>
+        public Expression ProcessAst(CommandAst commandAst, CompileVisitor visitor)
+        {
+            if (commandAst.CommandElements.Count != 3)
+            {
+                visitor.Errors.ReportParseError(
+                    commandAst.Extent,
+                    nameof(ErrorStrings.MissingKeywordElements),
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ErrorStrings.MissingKeywordElements,
+                        CommandName));
+                return Expression.Empty();
+            }
+
+            var bodyAst = commandAst.CommandElements[2] as ScriptBlockExpressionAst;
+            if (bodyAst == null)
+            {
+                visitor.Errors.ReportParseError(
+                    commandAst.Extent,
+                    nameof(ErrorStrings.MissingKeywordBody),
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ErrorStrings.MissingKeywordBody,
+                        CommandName));
+                return Expression.Empty();
+            }
+
+            return ProcessObjectAndBody(
+                commandAst,
+                commandAst.CommandElements[1],
+                bodyAst,
+                visitor);
+        }
+
+        /// <summary>
+        /// Creates a Linq expression for a <see cref="CommandAst" /> representing
+        /// a custom command.
+        /// </summary>
+        /// <param name="commandAst">The AST to convert.</param>
+        /// <param name="targetAst">The AST containing the target of the keyword.</param>
+        /// <param name="bodyAst">The AST containing the body of the keyword.</param>
+        /// <param name="visitor">The <see cref="CompileVisitor" /> requesting the expression.</param>
+        /// <returns>An expression representing the command.</returns>
+        protected abstract Expression ProcessObjectAndBody(
+            CommandAst commandAst,
+            CommandElementAst targetAst,
+            ScriptBlockExpressionAst bodyAst,
+            CompileVisitor visitor);
+    }
+}

--- a/src/PSLambda/ReflectionCache.cs
+++ b/src/PSLambda/ReflectionCache.cs
@@ -211,5 +211,19 @@ namespace PSLambda
         /// </summary>
         public static readonly MethodInfo ExpressionUtils_GetRange =
             typeof(ExpressionUtils).GetMethod("GetRange", BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// Resolves to <see cref="System.Threading.Monitor.Enter(object, ref bool)" />.
+        /// </summary>
+        public static readonly MethodInfo Monitor_Enter =
+            typeof(System.Threading.Monitor).GetMethod(
+                "Enter",
+                new[] { typeof(object), typeof(bool).MakeByRefType() });
+
+        /// <summary>
+        /// Resolves to <see cref="System.Threading.Monitor.Exit(object)" />.
+        /// </summary>
+        public static readonly MethodInfo Monitor_Exit =
+            typeof(System.Threading.Monitor).GetMethod("Exit", new[] { typeof(object) });
     }
 }

--- a/src/PSLambda/resources/ErrorStrings.resx
+++ b/src/PSLambda/resources/ErrorStrings.resx
@@ -156,11 +156,11 @@
   <data name="InvalidGenericSyntax" xml:space="preserve">
     <value>Invalid syntax for generic method invocation. The syntax is "generic($Target.Method(arguments), [type], [type])".</value>
   </data>
-  <data name="MissingWithBody" xml:space="preserve">
-    <value>The with statement requires the third argument to be a ScriptBlock expression.</value>
+  <data name="MissingKeywordBody" xml:space="preserve">
+    <value>The {0} keyword requires the third argument to be a ScriptBlock expression.</value>
   </data>
-  <data name="MissingWithElements" xml:space="preserve">
-    <value>The with statement requires both a expression that evaluates to a System.IDisposable object and ScriptBlock expression as arguments.</value>
+  <data name="MissingKeywordElements" xml:space="preserve">
+    <value>The {0} keyword requires both a target expression and a ScriptBlock expression as arguments.</value>
   </data>
   <data name="NoMemberNameMatch" xml:space="preserve">
     <value>'{0}' does not contain a definition for '{1}' and no extension method '{1}' accepting a first argument of type '{0}' could be found.</value>

--- a/test/Commands.Tests.ps1
+++ b/test/Commands.Tests.ps1
@@ -1,5 +1,7 @@
-using namespace System.Management.Automation
 using namespace System.Collections.ObjectModel
+using namespace System.Diagnostics
+using namespace System.Management.Automation
+using namespace System.Threading.Tasks
 
 $moduleName = 'PSLambda'
 $manifestPath = "$PSScriptRoot\..\Release\$moduleName\*\$moduleName.psd1"
@@ -28,5 +30,35 @@ Describe 'Custom command handlers' {
 
     It 'default' {
         ([psdelegate]{ default([ConsoleColor]) }).Invoke() | Should -Be ([System.ConsoleColor]::Black)
+    }
+
+    It 'lock' {
+        # Need a way better way to test this
+        $delegate = New-PSDelegate {
+            $syncObject = [object]::new()
+            $collection = [Collection[TimeSpan]]::new()
+            $stopWatch = [Stopwatch]::StartNew()
+
+            $tasks = [Collection[Task]]::new()
+            for ($i = 0; $i -lt 3; $i++) {
+                $tasks.Add(
+                    [Task]::Run({
+                        lock ($syncObject) {
+                            [System.Threading.Thread]::Sleep(100)
+                            $collection.Add($stopWatch.Elapsed)
+                            $stopWatch.Restart()
+                        }
+                    }))
+            }
+
+            [Task]::WaitAll($tasks.ToArray())
+            return $collection
+        }
+
+        $times = $delegate.Invoke()
+        foreach ($time in $times) {
+            $time.TotalMilliseconds | Should -BeGreaterThan 100
+            $time.TotalMilliseconds | Should -BeLessThan 150
+        }
     }
 }


### PR DESCRIPTION
This change adds the `lock` keyword for synchronizing access to an object across multiple threads.