### PR TITLE
Fix type inference in foreach statements

### DIFF
--- a/src/PSLambda/ExpressionUtils.cs
+++ b/src/PSLambda/ExpressionUtils.cs
@@ -185,7 +185,7 @@ namespace PSLambda
                             collectionVar,
                             Strings.AddMethodName,
                             Type.EmptyTypes,
-                            PSConvertTo<T>(Property(enumeratorVar, ReflectionCache.IEnumerator_Current))),
+                            PSConvertTo<T>(Call(enumeratorVar, ReflectionCache.IEnumerator_get_Current))),
                         Break(breakLabel)),
                     breakLabel),
                 Call(collectionVar, Strings.ToArrayMethodName, Type.EmptyTypes));
@@ -305,7 +305,7 @@ namespace PSLambda
                         IfThen(
                             PSEquals(
                                 item,
-                                Property(enumeratorVar, ReflectionCache.IEnumerator_Current),
+                                Call(enumeratorVar, ReflectionCache.IEnumerator_get_Current),
                                 isCaseSensitive),
                             Return(returnLabel, SpecialVariables.Constants[Strings.TrueVariableName])),
                         Return(returnLabel, SpecialVariables.Constants[Strings.FalseVariableName]))),

--- a/src/PSLambda/ReflectionCache.cs
+++ b/src/PSLambda/ReflectionCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
@@ -189,10 +190,16 @@ namespace PSLambda
             typeof(Hashtable).GetConstructor(new[] { typeof(int), typeof(IEqualityComparer) });
 
         /// <summary>
-        /// Resolves to <see cref="IEnumerator.Current" />
+        /// Resolves to <see cref="IEnumerator.get_Current" />
         /// </summary>
-        public static readonly PropertyInfo IEnumerator_Current =
-            typeof(IEnumerator).GetProperty("Current");
+        public static readonly MethodInfo IEnumerator_get_Current =
+            typeof(IEnumerator).GetMethod(Strings.EnumeratorGetCurrentMethodName, Type.EmptyTypes);
+
+        /// <summary>
+        /// Resolves to <see cref="IEnumerable.GetEnumerator" />
+        /// </summary>
+        public static readonly MethodInfo IEnumerable_GetEnumerator =
+            typeof(IEnumerable).GetMethod(Strings.GetEnumeratorMethodName, Type.EmptyTypes);
 
         /// <summary>
         /// Resolves to <see cref="StringComparer.CurrentCultureIgnoreCase" />.
@@ -225,5 +232,29 @@ namespace PSLambda
         /// </summary>
         public static readonly MethodInfo Monitor_Exit =
             typeof(System.Threading.Monitor).GetMethod("Exit", new[] { typeof(object) });
+
+        /// <summary>
+        /// Resolves to <see cref="IEnumerable{T}.GetEnumerator" />.
+        /// </summary>
+        public static readonly MethodInfo IEnumerable_T_GetEnumerator =
+            typeof(IEnumerable<>).GetMethod(Strings.GetEnumeratorMethodName, Type.EmptyTypes);
+
+        /// <summary>
+        /// Resolves to <see cref="IEnumerator{T}.get_Current" />.
+        /// </summary>
+        public static readonly MethodInfo IEnumerator_T_get_Current =
+            typeof(IEnumerator<>).GetMethod(Strings.EnumeratorGetCurrentMethodName, Type.EmptyTypes);
+
+        /// <summary>
+        /// Resolves to <see cref="IDictionary.GetEnumerator" />.
+        /// </summary>
+        public static readonly MethodInfo IDictionary_GetEnumerator =
+            typeof(IDictionary).GetMethod(Strings.GetEnumeratorMethodName, Type.EmptyTypes);
+
+        /// <summary>
+        /// Resolves to <see cref="IDictionaryEnumerator.get_Entry" />.
+        /// </summary>
+        public static readonly MethodInfo IDictionaryEnumerator_get_Entry =
+            typeof(IDictionaryEnumerator).GetMethod("get_Entry", Type.EmptyTypes);
     }
 }

--- a/src/PSLambda/Strings.cs
+++ b/src/PSLambda/Strings.cs
@@ -6,6 +6,16 @@ namespace PSLambda
     internal class Strings
     {
         /// <summary>
+        /// Constant containing a string similar to "GetEnumerator".
+        /// </summary>
+        public const string GetEnumeratorMethodName = "GetEnumerator";
+
+        /// <summary>
+        /// Constant containing a string similar to "get_Current".
+        /// </summary>
+        public const string EnumeratorGetCurrentMethodName = "get_Current";
+
+        /// <summary>
         /// Constant containing a string similar to "psdelegate".
         /// </summary>
         public const string PSDelegateTypeAcceleratorName = "psdelegate";

--- a/src/PSLambda/resources/ErrorStrings.resx
+++ b/src/PSLambda/resources/ErrorStrings.resx
@@ -168,4 +168,7 @@
   <data name="NoMemberArgumentMatch" xml:space="preserve">
     <value>'{0}' does not contain a definition for a method named '{1}' that takes the specified arguments.</value>
   </data>
+  <data name="ForEachInvalidEnumerable" xml:space="preserve">
+    <value>The foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for 'GetEnumerator'</value>
+  </data>
 </root>


### PR DESCRIPTION
Determine `GetEnumerable` and `get_Current` method by detecting `IEnumerable<>`, `IDictionary` or `IEnumerable` implementations.

Resolves #1